### PR TITLE
fix frac

### DIFF
--- a/chapter1/chapter1.tex
+++ b/chapter1/chapter1.tex
@@ -96,7 +96,7 @@ Iteriere dieses Verfahren $k$ mal, bis $n/2^{k} < 1$, Dann entsteht ein Widerspr
 
 \begin{corollary}
   Die Gleichung $z^{2} = 2$ hat keine rationale Lösung, das heisst,
-  keine Lösung der Form $z = p/q$ mit $p, q \in \mathbb N$ und $q > 0$.
+  keine Lösung der Form $z = \frac{p}{q}$ mit $p, q \in \mathbb N$ und $q > 0$.
 \end{corollary}
 
 Das Ziel für den Rest dieses Kapitels ist es, eine Zahlenmenge $\mathbb R$ (die Menge
@@ -230,7 +230,7 @@ Resultat.
   Wir konstruieren eine Bijektion $\varphi: \mathbb N \to \mathbb Q$.
   Für $k \in \mathbb N$ mit $k \geq 1$ definiere
   \[
-    A_{k} = \left\{p/q \mid p, q \in \mathbb Z, q \geq 1, p/q \textup{ ist gekürzt},
+    A_{k} = \left\{\frac{p}{q} \mid p, q \in \mathbb Z, q \geq 1, \frac{p}{q} \textup{ ist gekürzt},
     |p| + |q| = k\right\}.
   \]
   Alle solchen $A_{k} \subset \mathbb Q$ sind endlich und


### PR DESCRIPTION
Nur ein Vorkommnis geändert, da es sich durch das gesamte Dokument durchzieht.
Hier sonst noch ein guter Artikel, wie man diese automatisch beim schreiben ersetzen kann (jedenfalls mit vim): https://castel.dev/post/lecture-notes-1/